### PR TITLE
Changed get-latest-sha to get latest sha regardless if it was successful or not

### DIFF
--- a/.github/actions/get-latest-sha/action.yaml
+++ b/.github/actions/get-latest-sha/action.yaml
@@ -22,7 +22,6 @@ runs:
             repo: context.repo.repo,
             workflow_id: 'post-main-integration.yaml',
             branch: 'main',
-            status: 'success',
             per_page: 40 
           });
           const pushRuns = data.workflow_runs.filter(run => run.event === 'push');


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- removed 'success' filter when listing for last run of post-main-integration.yaml workflows, previously scheduled builds were taking potentially very old image that is not consistent with current version of tests 

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
